### PR TITLE
[Preflight] Add Kusto query for Denied policies

### DIFF
--- a/preflight/README.md
+++ b/preflight/README.md
@@ -1,4 +1,8 @@
-# Nerdio Manager Preflight script
+# Nerdio Manager Preflight tools
+
+[[toc]]
+
+## Script
 
 This script performs a pre-flight check for Nerdio Manager for Enterprise by attempting to create various Azure resources within a specified subscription and resource group. It verifies the ability to create resources that may be blocked by policy including a Log Analytics Workspace, Storage Account, SQL Server, SQL Database, App Service Plan, Automation Account, and Key Vault. Additionally, it will list the state of the required Resource Providers and roles assigned to the target resource group for the user account used to run the script.
 
@@ -6,10 +10,9 @@ The script is run interactively by targeting an Azure subscription, and optional
 
 The script will output the results of the success or failure to the console and write details of failures to a file in JSON format. The script also handles cleanup of created resources.
 
-Both a local PowerShell environment (Windows, macOS, Linux) and Azure Cloud Shell are supported for running the script.
-The script can take approximately 10 minutes to run.
+Both a local PowerShell environment (Windows, macOS, Linux) and Azure Cloud Shell are supported for running the script. The script can take approximately 10 minutes to run.
 
-## Usage
+### Usage
 
 The target subscription id is a required parameter for the script. An existing resource group can be optionally passed, otherwise you will be prompted to create a resource group.
 
@@ -25,7 +28,7 @@ Or specifying the target subscription only (you will be prompted to create a res
 .\Start-NerdioManagerPreFlight.ps1 -SubscriptionId "17c99779-9397-4bd4-b7c0-2cde094b9646"
 ```
 
-## Parameters
+### Parameters
 
 The script has the following parameters:
 
@@ -33,12 +36,12 @@ The script has the following parameters:
 * ResourceGroupName – optional. The resource group name in which the script will attempt to create resources. If not specified, the script will prompt for a resource group name and region, and attempt to create the resource group
 * OutFile – optional. Path to a JSON file that the failure events will be written to. Defaults to `NerdioManagerPreflightOutput.json` in the same directory as the script
 
-## Output
+### Output
 
 * JSON file - `NerdioManagerPreflightOutput.json` - in the same directory as the script, unless otherwise specified by -OutFile 
 * PSCustomObject output to the pipeline showing the result of failed tests – where possible, this includes the IDs of the policies blocking resource deployment. Details of target policies are not returned by all functions
 
-## Modules
+### Modules
 
 The script requires the following modules to be installed: 
 
@@ -50,13 +53,13 @@ In Azure Cloud Shell, the Az modules will already be installed. To install or up
 Install-Module –Name Az.Accounts, Az.Resources, Az.OperationalInsights, Az.Storage, Az.Sql, Az.Websites, Az.Automation, Az.KeyVault, Microsoft.PowerShell.ConsoleGuiTools
 ```
 
-## Script Considerations 
+### Script Considerations 
 
 Minimum rights required: 
 
 * Contributor on the target resource group
 
-## Authentication
+### Authentication
 
 The script requires you to authenticate to the target Azure tenant before running this script. Use the Connect-AzAccount cmdlet. For example:
 
@@ -64,14 +67,14 @@ The script requires you to authenticate to the target Azure tenant before runnin
 Connect-AzAccount -UseDeviceAuthentication
 ```
 
-## Running the script multiple times
+### Running the script multiple times
 
 The script will attempt to deploy several resources including those resources that have limitations on some subscription types and resources that are soft deleted. When testing by running the script multiple times, these resources might be created and deleted several times. There are limitations on some of these resources which may cause issues when attempting to create the same resources with the same name:
 
 * Automation accounts - in some subscription types, a limited number of Automation accounts can be deployed. These limits include deleted accounts that haven't yet been purged: [Azure subscription and service limits, quotas, and constraints](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#automation-limits)
 * Key vaults - deleted key vaults may need to be purged: [Azure Key Vault recovery management with soft delete and purge protection](https://learn.microsoft.com/en-us/azure/key-vault/general/key-vault-recovery?tabs=azure-portal)
 
-## Checks 
+### Checks 
 
 Checks include: 
 * Role assignments on target resource group if running locally. This check is skipped in Azure Cloud Shell because the account name does not match the user’s sign-in name.
@@ -84,7 +87,7 @@ Checks include:
     * Automation account 
     * Key vault 
 
-## Validating in a Lab
+### Validating in a Lab
 
 To validate blocking policies in a lab / test environment, configure an assignment for the **Not allowed resource types** to block resource types: [Tutorial: Disallow resource types in your cloud environment](https://learn.microsoft.com/en-us/azure/governance/policy/tutorials/disallowed-resources).
 
@@ -92,4 +95,40 @@ Use the following resource types in the policy assignment:
 
 ```json
 ["Microsoft.Automation/automationAccounts","Microsoft.KeyVault/vaults","Microsoft.OperationalInsights/workspaces","Microsoft.Sql/servers","Microsoft.Sql/servers/databases","Microsoft.Storage/storageAccounts","Microsoft.Web/serverFarms"]
+```
+
+## Kusto Query
+
+Here's a KQL query that should list Azure policies that are configured with a **Deny** effect. Export the list polices and review for potential issues before attempting to deploy Nerdio Manager.
+
+Run this in the Azure Resource Graph Explorer - the user running the query will need the **Resource Policy Reader** role, or **Reader** on the target subscription or management group. No other permissions in Azure should be required and no resources need to be deployed for testing.
+
+```kql
+policyresources
+| where type == "microsoft.authorization/policyassignments"
+| extend definitionId = tostring(properties.policyDefinitionId),
+         assignmentEffect = tostring(properties.parameters.effect.value)
+| join kind=leftouter (
+    policyresources
+    | where type == "microsoft.authorization/policydefinitions"
+    | extend defaultEffect = tostring(properties.parameters.effect.defaultValue),
+             hardCodedEffect = tostring(properties.policyRule.then.effect),
+             policyDisplayName = tostring(properties.displayName)
+    | project definitionId = id,
+              policyDisplayName,
+              hardCodedEffect,
+              defaultEffect
+) on definitionId
+| extend resolvedEffect = case(
+    isnotempty(assignmentEffect), assignmentEffect,
+    isnotempty(hardCodedEffect) and hardCodedEffect !~ "[parameters('effect')]", hardCodedEffect,
+    isnotempty(defaultEffect), defaultEffect,
+    "unknown"
+)
+| where resolvedEffect == "Deny"
+| project assignmentId = id,
+          assignmentName = name,
+          scope = properties.scope,
+          policyDisplayName,
+          resolvedEffect
 ```

--- a/preflight/README.md
+++ b/preflight/README.md
@@ -1,6 +1,6 @@
 # Nerdio Manager Preflight tools
 
-[[toc]]
+Listed here are scripts and queries to use a preflight tools to validate the target environment before attempting to deploy Nerdio Manager.
 
 ## Script
 
@@ -101,7 +101,7 @@ Use the following resource types in the policy assignment:
 
 Here's a KQL query that should list Azure policies that are configured with a **Deny** effect. Export the list polices and review for potential issues before attempting to deploy Nerdio Manager.
 
-Run this in the Azure Resource Graph Explorer - the user running the query will need the **Resource Policy Reader** role, or **Reader** on the target subscription or management group. No other permissions in Azure should be required and no resources need to be deployed for testing.
+Run this in the **Azure Resource Graph Explorer** - the user running the query will need the **Resource Policy Reader** role, or **Reader** on the target subscription or management group. No other permissions in Azure should be required and no resources need to be deployed for testing.
 
 ```kql
 policyresources

--- a/preflight/deny-policyassignments.kql
+++ b/preflight/deny-policyassignments.kql
@@ -1,0 +1,27 @@
+policyresources
+| where type == "microsoft.authorization/policyassignments"
+| extend definitionId = tostring(properties.policyDefinitionId),
+         assignmentEffect = tostring(properties.parameters.effect.value)
+| join kind=leftouter (
+    policyresources
+    | where type == "microsoft.authorization/policydefinitions"
+    | extend defaultEffect = tostring(properties.parameters.effect.defaultValue),
+             hardCodedEffect = tostring(properties.policyRule.then.effect),
+             policyDisplayName = tostring(properties.displayName)
+    | project definitionId = id,
+              policyDisplayName,
+              hardCodedEffect,
+              defaultEffect
+) on definitionId
+| extend resolvedEffect = case(
+    isnotempty(assignmentEffect), assignmentEffect,
+    isnotempty(hardCodedEffect) and hardCodedEffect !~ "[parameters('effect')]", hardCodedEffect,
+    isnotempty(defaultEffect), defaultEffect,
+    "unknown"
+)
+| where resolvedEffect == "Deny"
+| project assignmentId = id,
+          assignmentName = name,
+          scope = properties.scope,
+          policyDisplayName,
+          resolvedEffect


### PR DESCRIPTION
* Adds a Kusto query for Denied policies that returns a list of policies on a subscription or management group to enable reviewing before deploying Nerdio Manager
* Updates `README.md` with details