### PR TITLE
fix: correct preflight automation account check, cleanup, storage policy, and silent KeyVault failure

### DIFF
--- a/preflight/Start-NerdioManagerPreFlight.ps1
+++ b/preflight/Start-NerdioManagerPreFlight.ps1
@@ -353,7 +353,7 @@ if ($Response -match "^[Yy]$") {
                 AllowSharedKeyAccess            = $true
                 PublicNetworkAccess             = "Enabled"
                 RoutingChoice                   = "MicrosoftRouting"
-                AllowBlobPublicAccess           = $true
+                AllowBlobPublicAccess           = $false
                 MinimumTlsVersion               = "TLS1_2"
                 RequireInfrastructureEncryption = $false
                 Tag                             = $Tags
@@ -538,9 +538,10 @@ if ($Response -match "^[Yy]$") {
                     Tag                        = $Tags
                     ErrorAction                = "Stop"
                 }
-                $AutomationAccount = New-AzAutomationAccount @params *> $null
+                New-AzAutomationAccount @params *> $null
                 Write-Host -ForegroundColor "Cyan" "Waiting for the Automation Account to be created."
                 Start-Sleep -Seconds 10
+                $AutomationAccount = Get-AzAutomationAccount -ResourceGroupName $ResourceGroupName -Name $AutomationAccountName -ErrorAction "SilentlyContinue"
                 if ([System.String]::IsNullOrEmpty($AutomationAccount.AutomationAccountName)) {
                     Write-Host -ForegroundColor "Red" "[x] Failed to create a new Automation Account."
                     $OutputArray.Add($(New-PreflightObject -ExceptionMessage $Error[0].Exception.Message -Target "AutomationAccount")) | Out-Null
@@ -579,6 +580,8 @@ if ($Response -match "^[Yy]$") {
             }
         }
         catch {
+            Write-Host -ForegroundColor "Red" "[x] Failed to create a new Key Vault."
+            $OutputArray.Add($(New-PreflightObject -ExceptionMessage $_.Exception.Message -Target "KeyVault")) | Out-Null
         }
 
         Write-Host ""
@@ -629,7 +632,7 @@ if ($Response -match "^[Yy]$") {
                 Write-Host -ForegroundColor "Cyan" "Removing App Service Plan: '$($AppServicePlan.Name)'."
                 Remove-AzAppServicePlan -ResourceGroupName $ResourceGroupName -Name $AppServicePlan.Name -Force -ErrorAction "Continue"
             }
-            if (-not[System.String]::IsNullOrEmpty($AutomationAccountName.AutomationAccountName)) {
+            if (-not[System.String]::IsNullOrEmpty($AutomationAccount.AutomationAccountName)) {
                 Write-Host -ForegroundColor "Cyan" "Removing Automation Account: '$($AutomationAccount.AutomationAccountName)'."
                 Remove-AzAutomationAccount -ResourceGroupName $ResourceGroupName -Name $AutomationAccount.AutomationAccountName -Force -ErrorAction "Continue"
             }


### PR DESCRIPTION
## Summary

- **Automation account always reported as failed** — `New-AzAutomationAccount @params *> $null` suppressed the cmdlet's return value, so `$AutomationAccount` was always `$null`. The post-creation check therefore always printed failure even when Azure had created the account successfully. Fixed by following the same pattern used for SQL Server and App Service Plan: discard the return value with `*> $null`, then call `Get-AzAutomationAccount` after the sleep to populate `$AutomationAccount` from the live resource.

- **Automation account never cleaned up** — The cleanup guard checked `$AutomationAccountName.AutomationAccountName`. `$AutomationAccountName` is a `[String]`; it has no `.AutomationAccountName` property, so the guard was always empty and the account was never removed. Changed to `$AutomationAccount.AutomationAccountName`.

- **Storage account intermittently blocked by policy** — `AllowBlobPublicAccess = $true` triggers deny policies in many organisations, while Nerdio's actual deployment does not need public blob access. Changed to `$false` so the preflight does not fail on environments where the real deployment would succeed.

- **Key Vault failures silently swallowed** — The `catch` block after Key Vault creation was empty, so any failure was never recorded in `$OutputArray` or shown to the user. Wired up consistent error reporting matching every other resource.

Tested successfully in the ENT SE4 environment.
